### PR TITLE
Document Docker image architecture troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,34 @@ docker pull futurehouse/bixbench:aviary-notebook-env
 
 See [Docker's Getting Started Guide](https://docs.docker.com/get-started/) for instructions on how to set up Docker.
 
+### Docker image architecture troubleshooting
+
+The published `futurehouse/bixbench:aviary-notebook-env` image may not include a
+`linux/amd64` manifest. On an `amd64` host, Docker can therefore fail with:
+
+```text
+no matching manifest for linux/amd64 in the manifest list entries
+```
+
+Check the available platforms before pulling:
+
+```bash
+docker manifest inspect futurehouse/bixbench:aviary-notebook-env
+```
+
+If the image only lists `linux/arm64`, run it on an ARM64 machine or enable
+cross-platform emulation and pull the ARM64 variant explicitly:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install arm64
+docker pull --platform linux/arm64 futurehouse/bixbench:aviary-notebook-env
+```
+
+If you require native `linux/amd64` execution, use an image that has been rebuilt
+for `linux/amd64` or rebuild the BixBench notebook environment internally before
+running agentic evaluations. Zero-shot evaluation and postprocessing do not use
+this container.
+
 ## Quick Start
 
 For quick reproduction of BixBench results, we provide automated scripts that handle the entire evaluation pipeline:

--- a/README.md
+++ b/README.md
@@ -95,8 +95,11 @@ docker pull --platform linux/arm64 futurehouse/bixbench:aviary-notebook-env
 
 If you require native `linux/amd64` execution, use an image that has been rebuilt
 for `linux/amd64` or rebuild the BixBench notebook environment internally before
-running agentic evaluations. Zero-shot evaluation and postprocessing do not use
-this container.
+running agentic evaluations. A community member has also published an
+unofficial multi-architecture rebuild at `chenzizhao/bixbench:aviary-notebook-env`;
+verify that image independently before use, since it is not the Future House
+published image. Zero-shot evaluation and postprocessing do not use this
+container.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- document the `linux/amd64` manifest error reported in #41
- show how to inspect the published image manifest before pulling
- add an ARM64 emulation/pull workaround and clarify that native amd64 requires a rebuilt amd64-capable image
- mention the community multi-architecture rebuild from the issue thread as unofficial and independently verifiable, not as a Future House-published image
- note that zero-shot evaluation and postprocessing do not use the notebook container

Fixes #41
/claim #41

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/ihUsQETKr8S5vBRu

## Validation
- `python - <<'PY' ... PY` README assertion checked that the troubleshooting section contains the amd64 manifest error, the manifest inspection command, the ARM64 platform pull workaround, the community image caveat, and the zero-shot/postprocessing note
- `git diff --check`
